### PR TITLE
While Loop Ratelimit Errors

### DIFF
--- a/pyopenfec/utils.py
+++ b/pyopenfec/utils.py
@@ -70,7 +70,10 @@ class PyOpenFecApiClass(object):
                         cls.wait_time))
                 time.sleep(cls.wait_time)
                 response = requests.get(url, params=params)
-                cls.ratelimit_remaining = int(response.headers['x-ratelimit-remaining'])
+                if 'x-ratelimit-remaining' in response.headers:
+                    cls.ratelimit_remaining = int(response.headers['x-ratelimit-remaining'])
+                else:
+                    cls.ratelimit_remaining = 0
 
         cls.wait_time = 0.5
         return response


### PR DESCRIPTION
Fixes jeremyjbowers#27

This PR adds a check to ensure that the x-ratelimit-remaining header is set before attempting to access it, causing a KeyError. This header is currently not set for users who have had their API key's rate limit increased by the FEC, and the bug is encountered when that API key has precisely 0 API calls remaining.