### PR TITLE
Date formatting updates

### DIFF
--- a/pyopenfec/candidate.py
+++ b/pyopenfec/candidate.py
@@ -44,7 +44,7 @@ class Candidate(utils.PyOpenFecApiPaginatedClass, utils.SearchMixin):
             'first_file_date': '%Y-%m-%d',
             'last_f2_date': '%Y-%m-%d',
             'last_file_date': '%Y-%m-%d',
-            'load_date': '%Y-%m-%dT%H:%M:%S',
+            'load_date': '%Y-%m-%dT%H:%M:%S+00:00',
             }
 
         for k, v in kwargs.items():
@@ -132,7 +132,7 @@ class CandidateHistoryPeriod(utils.PyOpenFecApiPaginatedClass):
             'first_file_date': '%Y-%m-%d',
             'last_f2_date': '%Y-%m-%d',
             'last_file_date': '%Y-%m-%d',
-            'load_date': '%Y-%m-%dT%H:%M:%S',
+            'load_date': '%Y-%m-%dT%H:%M:%S+00:00',
             }
 
         for k, v in kwargs.items():

--- a/tests.py
+++ b/tests.py
@@ -68,7 +68,6 @@ class CommitteeTest(unittest.TestCase):
             example = donation
         self.assertIsInstance(example.contribution_receipt_date, datetime)
         self.assertIsInstance(example.load_date, datetime)
-        self.assertIsInstance(example.timestamp, datetime)
 
     def test_schedule_b_dates(self):
         example = None


### PR DESCRIPTION
Two small changes to how the FEC is formatting data in its API responses. We started noticing these changes on December 20, 2018